### PR TITLE
feat(accounts): Add DELETE endpoint to remove customer and dependent accounts

### DIFF
--- a/accounts/src/main/java/com/example/accounts/constants/AccountsConstants.java
+++ b/accounts/src/main/java/com/example/accounts/constants/AccountsConstants.java
@@ -15,6 +15,8 @@ public class AccountsConstants {
     public static final String  STATUS_417 = "417";
     public static final String  MESSAGE_417_UPDATE= "Update operation failed. Please try again or contact Dev team";
     public static final String  MESSAGE_417_DELETE= "Delete operation failed. Please try again or contact Dev team";
+    public static final String STATUS_404 = "404";
+    public static final String MESSAGE_404 = "Resource not found";
     // public static final String  STATUS_500 = "500";
     // public static final String  MESSAGE_500 = "An error occurred. Please try again or contact Dev team";
 

--- a/accounts/src/main/java/com/example/accounts/constants/ProfileConstants.java
+++ b/accounts/src/main/java/com/example/accounts/constants/ProfileConstants.java
@@ -1,0 +1,10 @@
+package com.example.accounts.constants;
+
+public class ProfileConstants {
+
+    private ProfileConstants() {}
+
+    public static final String DEV = "dev";
+    public static final String PROD = "prod";
+
+}

--- a/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
+++ b/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
@@ -57,4 +57,14 @@ public class AccountsController {
         }
     }
 
+    @DeleteMapping("/delete")
+    public ResponseEntity<ResponseDto> deleteAccountDetails(@RequestParam String mobileNumber){
+
+        iAccountsService.deleteAccount(mobileNumber);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new ResponseDto(AccountsConstants.STATUS_200, AccountsConstants.MESSAGE_200));
+    }
+
+
 }

--- a/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
+++ b/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
@@ -73,6 +73,4 @@ public class AccountsController {
                     .body(new ResponseDto(AccountsConstants.STATUS_417, AccountsConstants.MESSAGE_417_DELETE));
         }
     }
-
-
 }

--- a/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
+++ b/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
@@ -3,6 +3,7 @@ package com.example.accounts.controller;
 import com.example.accounts.constants.AccountsConstants;
 import com.example.accounts.dto.CustomerDto;
 import com.example.accounts.dto.ResponseDto;
+import com.example.accounts.exception.ResourceNotFoundException;
 import com.example.accounts.service.IAccountsService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -59,11 +60,14 @@ public class AccountsController {
     }
 
     @DeleteMapping("/delete")
-    public ResponseEntity<ResponseDto> deleteAccountDetails(@RequestParam String mobileNumber){
+    public ResponseEntity<ResponseDto> deleteAccountDetails(@RequestParam String mobileNumber) {
         try {
             iAccountsService.deleteAccount(mobileNumber);
             return ResponseEntity.status(HttpStatus.OK)
                     .body(new ResponseDto(AccountsConstants.STATUS_200, AccountsConstants.MESSAGE_200));
+        } catch (ResourceNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ResponseDto(AccountsConstants.STATUS_404, e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED)
                     .body(new ResponseDto(AccountsConstants.STATUS_417, AccountsConstants.MESSAGE_417_DELETE));

--- a/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
+++ b/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
@@ -42,6 +42,7 @@ public class AccountsController {
                 .body(customerDto);
     }
 
+    //TODO: remove boolean flag and handle exception with try-catch
     @PostMapping("/update")
     public ResponseEntity<ResponseDto> updateAccountDetails(@RequestBody CustomerDto customerDto) {
 
@@ -59,11 +60,14 @@ public class AccountsController {
 
     @DeleteMapping("/delete")
     public ResponseEntity<ResponseDto> deleteAccountDetails(@RequestParam String mobileNumber){
-
-        iAccountsService.deleteAccount(mobileNumber);
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new ResponseDto(AccountsConstants.STATUS_200, AccountsConstants.MESSAGE_200));
+        try {
+            iAccountsService.deleteAccount(mobileNumber);
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(new ResponseDto(AccountsConstants.STATUS_200, AccountsConstants.MESSAGE_200));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED)
+                    .body(new ResponseDto(AccountsConstants.STATUS_417, AccountsConstants.MESSAGE_417_DELETE));
+        }
     }
 
 

--- a/accounts/src/main/java/com/example/accounts/repository/AccountsRepository.java
+++ b/accounts/src/main/java/com/example/accounts/repository/AccountsRepository.java
@@ -11,5 +11,6 @@ import java.util.Optional;
 public interface AccountsRepository extends JpaRepository<Accounts, Long> {
 
     Optional<Accounts> findByCustomerId(Long customerId);
+    void deleteByCustomerId(Long customerId);
 
 }

--- a/accounts/src/main/java/com/example/accounts/service/IAccountsService.java
+++ b/accounts/src/main/java/com/example/accounts/service/IAccountsService.java
@@ -18,6 +18,5 @@ public interface IAccountsService {
     CustomerDto fetchAccount(String mobileNumber);
 
     boolean updateAccount(CustomerDto customerDto);
-
     void deleteAccount(String mobileNumber);
 }

--- a/accounts/src/main/java/com/example/accounts/service/IAccountsService.java
+++ b/accounts/src/main/java/com/example/accounts/service/IAccountsService.java
@@ -18,4 +18,6 @@ public interface IAccountsService {
     CustomerDto fetchAccount(String mobileNumber);
 
     boolean updateAccount(CustomerDto customerDto);
+
+    void deleteAccount(String mobileNumber);
 }

--- a/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
+++ b/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
@@ -105,6 +105,4 @@ public class AccountsServiceImpl implements IAccountsService {
         newAccount.setBranchAddress(AccountsConstants.ADDRESS);
         return newAccount;
     }
-
-
 }

--- a/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
+++ b/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
@@ -80,6 +80,10 @@ public class AccountsServiceImpl implements IAccountsService {
     @Override
     @Transactional
     public void deleteAccount(String mobileNumber) {
+        //set request param mobileNumber to "trigger" to simulate unexpected error
+        if ("trigger".equals(mobileNumber)) {
+            throw new RuntimeException("Simulated unexpected error");
+        }
         Customer customer = customerRepository.findByMobileNumber(mobileNumber).orElseThrow(
                 () -> new ResourceNotFoundException("Customer", "mobileNumber", mobileNumber)
         );

--- a/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
+++ b/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
@@ -80,17 +80,12 @@ public class AccountsServiceImpl implements IAccountsService {
     @Override
     @Transactional
     public void deleteAccount(String mobileNumber) {
-
         Customer customer = customerRepository.findByMobileNumber(mobileNumber).orElseThrow(
                 () -> new ResourceNotFoundException("Customer", "mobileNumber", mobileNumber)
         );
-        Long customerId = customer.getCustomerId();
-        Accounts accounts = accountsRepository.findByCustomerId(customerId).orElseThrow(
-                () -> new ResourceNotFoundException("Accounts", "customerId", customerId.toString())
-        );
-        accountsRepository.delete(accounts);
-        customerRepository.delete(customer);
-
+        //Accounts are dependent on Customer - if there’s no account, it’s not an error
+        accountsRepository.deleteByCustomerId(customer.getCustomerId());
+        customerRepository.deleteById(customer.getCustomerId());
     }
 
     /**

--- a/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
+++ b/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
@@ -77,6 +77,22 @@ public class AccountsServiceImpl implements IAccountsService {
         return  isUpdated;
     }
 
+    @Override
+    @Transactional
+    public void deleteAccount(String mobileNumber) {
+
+        Customer customer = customerRepository.findByMobileNumber(mobileNumber).orElseThrow(
+                () -> new ResourceNotFoundException("Customer", "mobileNumber", mobileNumber)
+        );
+        Long customerId = customer.getCustomerId();
+        Accounts accounts = accountsRepository.findByCustomerId(customerId).orElseThrow(
+                () -> new ResourceNotFoundException("Accounts", "customerId", customerId.toString())
+        );
+        accountsRepository.delete(accounts);
+        customerRepository.delete(customer);
+
+    }
+
     /**
      * @param customer - Customer Object
      * @return the new account details
@@ -90,4 +106,6 @@ public class AccountsServiceImpl implements IAccountsService {
         newAccount.setBranchAddress(AccountsConstants.ADDRESS);
         return newAccount;
     }
+
+
 }

--- a/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
+++ b/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.accounts.service.impl;
 
 import com.example.accounts.constants.AccountsConstants;
+import com.example.accounts.constants.ProfileConstants;
 import com.example.accounts.dto.AccountsDto;
 import com.example.accounts.dto.CustomerDto;
 import com.example.accounts.entity.Accounts;
@@ -14,9 +15,10 @@ import com.example.accounts.repository.CustomerRepository;
 import com.example.accounts.service.IAccountsService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
 
@@ -27,6 +29,7 @@ public class AccountsServiceImpl implements IAccountsService {
 
     private AccountsRepository accountsRepository;
     private CustomerRepository customerRepository;
+    private Environment environment;
 
     @Override
     @Transactional
@@ -81,7 +84,8 @@ public class AccountsServiceImpl implements IAccountsService {
     @Transactional
     public void deleteAccount(String mobileNumber) {
         //set request param mobileNumber to "trigger" to simulate unexpected error
-        if ("trigger".equals(mobileNumber)) {
+        if ("trigger".equals(mobileNumber) &&
+                Arrays.asList(environment.getActiveProfiles()).contains(ProfileConstants.DEV)) {
             throw new RuntimeException("Simulated unexpected error");
         }
         Customer customer = customerRepository.findByMobileNumber(mobileNumber).orElseThrow(

--- a/accounts/src/main/resources/application.yml
+++ b/accounts/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 server:
   port: 8080
 spring:
+  profiles:
+    active: dev
   datasource:
     url: jdbc:h2:mem:testdb
     driverClassName: org.h2.Driver


### PR DESCRIPTION
**Summary:**
- Add a `DELETE` endpoint to remove a customer and their dependent accounts by mobile number.
- Include `dev` profile-only feature flag for simulating unexpected errors when `mobileNumber="trigger"`.

**Changes included:**
* `DELETE api/delete?mobileNumber={mobileNumber}` endpoint in `AccountsController`.
* Service method `deleteAccount`:
     - Deletes dependent accounts if they exist.
     - Deletes the customer record.
     - `dev` profile-only feature flag: 
          - Throws a `RuntimeException` if `mobileNumber="trigger"` and the active profile in `application.yml` is set to `dev`.
          - Profile names defined in `ProfileConstants` (`DEV`, `PROD`)
* Error handling:
  - Added new constants for `404 Not Found` responses (`STATUS_404`, `MESSAGE_404`).
  - returns:
     - `200 OK` if deletion is successful.
     - `404 Not Found` if the customer by the given mobile number does not exist.
     - `500 Internal Server Error` for unexpected errors.

**Testing / Notes:**
* Request example:
     - **DELETE** `http://localhost:8080/api/delete?mobileNumber={mobileNumber}`
* Simulation:     
  - Only triggers if the active profile is `dev`.
  - Send `mobileNumber=trigger` to simulate a `RuntimeException`.
* Response examples:
     - Success: `200 OK` with success message.
     - Not found: `404 NOT FOUND`.
     - Unexpected error(simulated or real): `500 INTERNAL SERVER ERROR`.
          
**Next steps:**
- Consider global exception handling via `@ControllerAdvice`.