### PR TITLE
feat(dev): Add FeatureFlags class with profile-based flag map

### DIFF
--- a/accounts/src/main/java/com/example/accounts/config/FeatureFlags.java
+++ b/accounts/src/main/java/com/example/accounts/config/FeatureFlags.java
@@ -3,26 +3,46 @@ package com.example.accounts.config;
 import com.example.accounts.constants.ProfileConstants;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import java.util.Map;
 import java.util.Set;
 
+/**
+ * FeatureFlags is a flag-centric, profile-aware feature toggle system.
+ *
+ * This class allows enabling/disabling features per Spring profile This class allows enabling/disabling features per Spring profile.
+ * Currently, it only supports 'profile-based flags'. Future expansions could include user-level, beta, or other conditional flags.
+ */
 @Component
 public class FeatureFlags {
 
     public static final String DELETE_ACCOUNT_EXCEPTION_SIMULATION = "trigger";
 
-    //Keeps a registry of all dev-only flags.
-    private static final Set<String> DEV_FLAGS = Set.of(
-            DELETE_ACCOUNT_EXCEPTION_SIMULATION
+    /**
+     * FLAG_PROFILE_MAP maps a feature flag → set of allowed profiles.
+     * Immutable map and sets, safe for concurrent read-only use.
+     */
+    private static final Map<String, Set<String>> FLAG_PROFILE_MAP = Map.of(
+            DELETE_ACCOUNT_EXCEPTION_SIMULATION, Set.of(ProfileConstants.DEV)
     );
 
+    //Current Spring profile (injected)
     //Spring can only inject values into an instance, not into static fields.
     @Value("${spring.profiles.active}")
     private String activeProfile;
 
     //Instance method because it reads activeProfile, which is per-instance injected by Spring.
     //Static method only reads static fields.
-    public boolean isDevFeatureEnabled(String flagName) {
-        return ProfileConstants.DEV.equalsIgnoreCase(activeProfile) && DEV_FLAGS.contains(flagName);
+    /**
+     * Checks if a given flag is enabled for the current active profile.
+     *
+     * @param flagName the name of the feature flag
+     * @return true if the flag is enabled in the current profile, false otherwise
+     */
+    public boolean isFeatureEnabled(String flagName) {
+        //Set.of: create immutable set (unlike HashSet)
+        //getOrDefault: if flagName is not found, return empty set, prevent NullPointerException
+        Set<String> allowedProfiles = FLAG_PROFILE_MAP.getOrDefault(flagName, Set.of());
+        return allowedProfiles.contains(activeProfile.toLowerCase());
     }
 
 }

--- a/accounts/src/main/java/com/example/accounts/config/FeatureFlags.java
+++ b/accounts/src/main/java/com/example/accounts/config/FeatureFlags.java
@@ -1,0 +1,28 @@
+package com.example.accounts.config;
+
+import com.example.accounts.constants.ProfileConstants;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import java.util.Set;
+
+@Component
+public class FeatureFlags {
+
+    public static final String DELETE_ACCOUNT_EXCEPTION_SIMULATION = "trigger";
+
+    //Keeps a registry of all dev-only flags.
+    private static final Set<String> DEV_FLAGS = Set.of(
+            DELETE_ACCOUNT_EXCEPTION_SIMULATION
+    );
+
+    //Spring can only inject values into an instance, not into static fields.
+    @Value("${spring.profiles.active}")
+    private String activeProfile;
+
+    //Instance method because it reads activeProfile, which is per-instance injected by Spring.
+    //Static method only reads static fields.
+    public boolean isDevFeatureEnabled(String flagName) {
+        return ProfileConstants.DEV.equalsIgnoreCase(activeProfile) && DEV_FLAGS.contains(flagName);
+    }
+
+}

--- a/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
+++ b/accounts/src/main/java/com/example/accounts/service/impl/AccountsServiceImpl.java
@@ -88,7 +88,7 @@ public class AccountsServiceImpl implements IAccountsService {
     @Transactional
     public void deleteAccount(String mobileNumber) {
         if (FeatureFlags.DELETE_ACCOUNT_EXCEPTION_SIMULATION.equals(mobileNumber) &&
-                featureFlags.isDevFeatureEnabled(FeatureFlags.DELETE_ACCOUNT_EXCEPTION_SIMULATION)) {
+                featureFlags.isFeatureEnabled(FeatureFlags.DELETE_ACCOUNT_EXCEPTION_SIMULATION)) {
             throw new RuntimeException("Simulated unexpected error");
         }
         Customer customer = customerRepository.findByMobileNumber(mobileNumber).orElseThrow(


### PR DESCRIPTION
**Summary:**
- Added `FeatureFlags` class to manage feature toggles in a flag-centric, profile-aware way.

**Description:**
- Introduced `FLAG_PROFILE_MAP` to map each flag to allowed Spring profiles (currently `dev` only).
- Added `isFeatureEnabled()` method to check if a flag is enabled in the current profile.
- Future-proof for user-level, beta, or other conditional flags.

**Notes:**
- Inline comments are kept intentionally for **learning purposes**.
- They explain design decisions (e.g., why `FLAG_PROFILE_MAP` is immutable, why DI uses `private final` fields).
- They do not affect runtime behavior and can be safely ignored in production.