### PR TITLE
feature: enable JPA audit

### DIFF
--- a/accounts/src/main/java/com/example/accounts/AccountsApplication.java
+++ b/accounts/src/main/java/com/example/accounts/AccountsApplication.java
@@ -2,8 +2,10 @@ package com.example.accounts;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing(auditorAwareRef = "auditAwareImpl")
 public class AccountsApplication {
 
 	public static void main(String[] args) {

--- a/accounts/src/main/java/com/example/accounts/audit/AuditAwareImpl.java
+++ b/accounts/src/main/java/com/example/accounts/audit/AuditAwareImpl.java
@@ -1,0 +1,20 @@
+package com.example.accounts.audit;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component("auditAwareImpl")
+public class AuditAwareImpl implements AuditorAware {
+
+    //TODO: modify the existing method to get current user from security context
+    // OR (✅recommended) create a new implementation of AuditorAware and switch using DI
+    // -option1. reuse the same component name "auditAwareImpl" for the new class
+    // -option2. use @Profile to switch between implementations (@Profile("dev") → this class, @Profile("prod") → SecurityAuditorAwareImpl)
+    // -option3. use @Primary to mark the default implementation when multiple components exist
+    @Override
+    public Optional getCurrentAuditor() {
+        return Optional.of("ACCOUNTS_MS");
+    }
+}

--- a/accounts/src/main/java/com/example/accounts/entity/BaseEntity.java
+++ b/accounts/src/main/java/com/example/accounts/entity/BaseEntity.java
@@ -1,41 +1,48 @@
 package com.example.accounts.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-@MappedSuperclass
+@MappedSuperclass //allows entities to inherit fields
+@EntityListeners(AuditingEntityListener.class) //tracks all entities(create, update, delete) that extend this BaseEntity
 @Getter @Setter @ToString
 public class BaseEntity {
 
+    @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    @CreatedBy
     @Column(updatable = false)
     private String createdBy;
 
+    @LastModifiedDate
     @Column(insertable = false)
     private LocalDateTime updatedAt;
 
+    @LastModifiedBy
     @Column(insertable = false)
     private String updatedBy;
 
-    @PrePersist
-    public void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.createdBy = "SYSTEM"; // or fetch from security context
-    }
-
-    @PreUpdate
-    public void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-        this.updatedBy = "SYSTEM"; // or fetch from security context
-    }
+//    @PrePersist
+//    public void onCreate() {
+//        this.createdAt = LocalDateTime.now();
+//        this.createdBy = "SYSTEM"; // or fetch from security context
+//    }
+//
+//    @PreUpdate
+//    public void onUpdate() {
+//        this.updatedAt = LocalDateTime.now();
+//        this.updatedBy = "SYSTEM"; // or fetch from security context
+//    }
 
 }


### PR DESCRIPTION
**Summary:**
- Introduced JPA auditing support via `@EnableJpaAuditing(auditorAwareRef = "auditAwareImpl")` (custom `AuditorAware` component).
- Added `AuditingEntityListener`(default Spring Listener) at `BaseEntity` so that all child entities are automatically hooked for lifecycle events and have auditing fields populated.

**Details:**
- `EntityListeners` track entities during lifecycle events (insert, update, delete).
- `AuditingEntityListener` automatically populates:
     `@CreatedDate`, `@LastModifiedDate`
     `@CreatedBy`, `@LastModifiedBy` (values provided by `AuditorAware`).
- Supports custom entity listeners as well (`@Pre/PostPersist/Update/Remove`).

**`BaseEntity` role**
- Can be extended with additional custom fields if needed:
   ex) deletedAt, deletedBy, version, ipAddress, requestId, sourceSystem, etc.
   * **Soft deletes** → deletedAt, deletedBy
   * **Optimistic locking / concurrency control** → `@Version` on version
   * **Traceability** → ipAddress, requestId, sourceSystem for logging/debugging across distributed systems

---
**TODO:**
also added as inline comments in the code for future reference.

✅ **Dependency Injection (DI) considerations:** 
- Current `AuditAwareImpl` returns hard coded "SYSTEM".
- Future option: add `SecurityAuditorAwareImpl` to fetch the logged-in user from `Spring Security`.
- Switching can be handled via DI:
  - **option1**. Reuse the existing component name
  - **option2.** use `@Profile` for `dev/prod`
  - **option3.** use `@Primary` when multiple beans exist

✅ **`BaseEntity` extension:**
- Keep `BaseEntity` simple (only core auditing fields).
- If additional fields are needed (e.g., deletedAt, requestId, sourceSystem):
     - **option1.** Specialized base class → create SoftDeletableEntity, TraceableEntity, etc., that extend `BaseEntity`.
     - **option2.** Add directly in the entity if it’s domain-specific.
- For populating those additional fields:
     - **option1.** Custom entity listener → automatically set values (e.g., deletedAt on soft delete).
     - **option2.** Service layer → manually set values before persistence when automation is not suitable.