### PR TITLE
feature: add Springdoc-openapi annotations for API documentation

### DIFF
--- a/accounts/build.gradle
+++ b/accounts/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
 }
 
 tasks.named('test') {

--- a/accounts/src/main/java/com/example/accounts/AccountsApplication.java
+++ b/accounts/src/main/java/com/example/accounts/AccountsApplication.java
@@ -1,11 +1,36 @@
 package com.example.accounts;
 
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "auditAwareImpl")
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Accounts microservice REST API documentation",
+        description = "Accounts REST API documentation",
+        version = "1.0",
+        contact = @Contact(
+            name = "dev",
+            email = "dev@mail.com",
+            url = "https://www.example.com"
+        ),
+        license = @License(
+            name = "MIT License",
+            url = "https://choosealicense.com/licenses/mit/"
+        )
+    ),
+    externalDocs = @ExternalDocumentation(
+            description = "Accounts Service REST API Documentation",
+            url = "https://example.com/swagger-ui/index.html"
+    )
+)
 public class AccountsApplication {
 
 	public static void main(String[] args) {

--- a/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
+++ b/accounts/src/main/java/com/example/accounts/controller/AccountsController.java
@@ -2,8 +2,15 @@ package com.example.accounts.controller;
 
 import com.example.accounts.constants.AccountsConstants;
 import com.example.accounts.dto.CustomerDto;
+import com.example.accounts.dto.ErrorResponseDto;
 import com.example.accounts.dto.ResponseDto;
 import com.example.accounts.service.IAccountsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -14,6 +21,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(
+    name = "CRUD REST APIs for Accounts",
+    description = "CREATE, FETCH, UPDATE and DELETE account details")
 @Slf4j
 @AllArgsConstructor
 @Validated
@@ -27,24 +37,46 @@ public class AccountsController {
         return ResponseEntity.status(httpStatus).body(new ResponseDto(status, message));
     }
 
+    @Operation(summary = "Create Account", description = "Create a new Customer and Account")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "HTTP Status 201 Created"),
+        @ApiResponse(responseCode = "409", description = "HTTP Status 409 Conflict", content=@Content(schema=@Schema(implementation=ErrorResponseDto.class)))
+    })
     @PostMapping("/create")
     public ResponseEntity<ResponseDto> createAccount(@Valid @RequestBody CustomerDto customerDto){
         iAccountsService.createAccount(customerDto);
         return buildSuccessResponse(HttpStatus.CREATED, AccountsConstants.STATUS_201, AccountsConstants.MESSAGE_201);
     }
 
+    @Operation(summary = "Fetch Account details", description = "Fetch Customer and Account details based on the given mobile number")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "HTTP Status 200 OK"),
+        @ApiResponse(responseCode = "400", description = "HTTP Status 400 Bad Request", content=@Content(schema=@Schema(implementation=ErrorResponseDto.class))),
+        @ApiResponse(responseCode = "404", description = "HTTP Status 404 Not Found", content=@Content(schema=@Schema(implementation=ErrorResponseDto.class)))
+    })
     @GetMapping("/fetch")
     public ResponseEntity<CustomerDto> fetchAccountDetails(@RequestParam @Pattern(regexp = "^\\d{11}$", message="Mobile number must be 11 digits")                                                     String mobileNumber){
         CustomerDto customerDto = iAccountsService.fetchAccount(mobileNumber);
         return ResponseEntity.ok(customerDto);
     }
 
+    @Operation(summary = "Update Account details", description = "Update Customer and Account details based on the given account number")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "HTTP Status 200 OK"),
+        @ApiResponse(responseCode = "400", description = "HTTP Status 400 Bad Request", content=@Content(schema=@Schema(implementation=ErrorResponseDto.class))),
+        @ApiResponse(responseCode = "404", description = "HTTP Status 404 Not Found", content=@Content(schema=@Schema(implementation=ErrorResponseDto.class)))
+    })
     @PostMapping("/update")
     public ResponseEntity<ResponseDto> updateAccountDetails(@Valid @RequestBody CustomerDto customerDto) {
         iAccountsService.updateAccount(customerDto);
         return buildSuccessResponse(HttpStatus.OK, AccountsConstants.STATUS_200, AccountsConstants.MESSAGE_200);
     }
 
+    @Operation(summary = "Delete Customer and Account details", description = "Delete Customer and Account details based on the given mobile number")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "HTTP Status 200 OK"),
+            @ApiResponse(responseCode = "404", description = "HTTP Status 404 Not Found", content=@Content(schema=@Schema(implementation=ErrorResponseDto.class)))
+    })
     @DeleteMapping("/delete")
     public ResponseEntity<ResponseDto> deleteAccountDetails(@RequestParam @Pattern(regexp = "^\\d{11}$", message="Mobile number must be 11 digits")                                                         String mobileNumber) {
         iAccountsService.deleteAccount(mobileNumber);

--- a/accounts/src/main/java/com/example/accounts/dto/AccountsDto.java
+++ b/accounts/src/main/java/com/example/accounts/dto/AccountsDto.java
@@ -3,9 +3,7 @@ package com.example.accounts.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Data;
-import org.hibernate.validator.constraints.Length;
 
 @Schema(
     name ="Accounts",

--- a/accounts/src/main/java/com/example/accounts/dto/AccountsDto.java
+++ b/accounts/src/main/java/com/example/accounts/dto/AccountsDto.java
@@ -1,23 +1,30 @@
 package com.example.accounts.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;
 
+@Schema(
+    name ="Accounts",
+    description = "Schema to represent Accounts details")
 @Data
 public class AccountsDto {
 
     // NOTE: Validation constraints must be applied to compatible data types
     //@NotEmpty(message="Account number is required")
     //@Pattern(regexp = "^\\d{10}$", message="Account number must be 10 digits")
+    @Schema(description = "Account number", example = "1234567890")
     @NotNull(message="Account number is required")
     private Long accountNumber;
 
+    @Schema(description = "Account type", example = "Savings")
     @NotEmpty(message="Account type is required")
     private String accountType;
 
+    @Schema(description = "Branch address", example = "123 Main St, Anytown, USA")
     @NotEmpty(message="Branch address is required")
     private String branchAddress;
 }

--- a/accounts/src/main/java/com/example/accounts/dto/CustomerDto.java
+++ b/accounts/src/main/java/com/example/accounts/dto/CustomerDto.java
@@ -1,23 +1,42 @@
 package com.example.accounts.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.Data;
 
 @Data
+@Schema(
+    name = "Customer",
+    description = "Schema to represent Customer and Account details"
+)
 public class CustomerDto {
 
+    @Schema(
+        description = "Name of the customer",
+        example = "John Doe"
+    )
     @NotEmpty(message="Name is required")
     @Size(min = 2, max = 50, message="Name should be between 2 and 50 characters")
     private String name;
 
+    @Schema(
+        description = "Email of the customer",
+        example = "john.doe@example.com")
     @NotEmpty(message="Email is required")
     @Email(message="Email should be valid")
     private String email;
 
+    @Schema(
+        description = "Mobile number of the customer",
+        example = "01012345678"
+    )
     @Pattern(regexp = "^\\d{11}$", message="Mobile number must be 11 digits")
     private String mobileNumber;
 
+    @Schema(
+        description = "Accounts details of the customer"
+    )
     @Valid
     private AccountsDto accountsDto;
 }

--- a/accounts/src/main/java/com/example/accounts/dto/ErrorResponseDto.java
+++ b/accounts/src/main/java/com/example/accounts/dto/ErrorResponseDto.java
@@ -1,15 +1,28 @@
 package com.example.accounts.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 
+@Schema(
+    name = "Error Response",
+    description = "Schema to represent error response"
+)
 @Data @AllArgsConstructor
 public class ErrorResponseDto {
+
+    @Schema(description = "API path that triggered the error", example = "/api/create")
     private String apiPath;
+
+    @Schema(description = "Error code", example = "BAD_REQUEST")
     private HttpStatus errorCode;
+
+    @Schema(description = "Error message", example = "Customer already registered with given mobile number 01012345678")
     private String errorMessage;
+
+    @Schema(description = "Error time", example = "2100-01-01T00:00:00")
     private LocalDateTime errorTime;
 }

--- a/accounts/src/main/java/com/example/accounts/dto/ResponseDto.java
+++ b/accounts/src/main/java/com/example/accounts/dto/ResponseDto.java
@@ -1,12 +1,18 @@
 package com.example.accounts.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+@Schema(
+    name = "Success Response",
+    description = "Schema to represent successful response")
 @Data
 @AllArgsConstructor
 public class ResponseDto {
+    @Schema(description = "Status code in the response", example = "200")
     private String status;
+    @Schema(description = "Status message in the response", example = "Request processed successfully")
     private String message;
 }
 

--- a/accounts/src/main/resources/application.yml
+++ b/accounts/src/main/resources/application.yml
@@ -1,5 +1,8 @@
+# Server
 server:
   port: 8080
+
+# Spring
 spring:
   profiles:
     active: dev
@@ -16,6 +19,11 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
-  logging:
-    level:
-      root: TRACE
+  output:
+    ansi:
+      enabled: always
+
+# Logging TRACE < DEBUG < INFO < WARN < ERROR
+logging:
+  level:
+    root: INFO


### PR DESCRIPTION
- add **Springdoc-openapi** dependency
`implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'`

1. **Application `AccountsApplication`**
   - `@OpenAPIDefinition` on **main application class** for global API metadata

2. **DTO `Customer`, `Accounts`, `ResponseDto`, `ErroeResponseDto`**
     - `@Schema` on DTO classes and fields for better model descriptions.

3. **Controller `AccountsController`**
     - `@Tag` on **controller classes** to group related endpoints.
     - `@Operation` on **controller methods** to describe each endpoint.
     - `@ApiResponse` on **controller methods** to document possible HTTP responses.
